### PR TITLE
Small fix for the armor names of horse, llama, wolf

### DIFF
--- a/configuration/custom-mob-armor-1.21.2+/README.md
+++ b/configuration/custom-mob-armor-1.21.2+/README.md
@@ -10,7 +10,7 @@ forest_wolf_armor:
   Pack:
     texture: nexo:item/nexo_armor/forest_wolf_armor_icon
     CustomArmor:
-      llama_armor: nexo:item/nexo_armor/forest_wolf_armor
+      wolf_armor: nexo:item/nexo_armor/forest_wolf_armor
 forest_llama_armor:
   itemname: "Forest Llama Carpet"
   material: PAPER
@@ -24,5 +24,5 @@ forest_horse_armor:
   Pack:
     texture: nexo:item/nexo_armor/forest_horse_armor_icon
     CustomArmor:
-      llama_armor: nexo:item/nexo_armor/forest_horse_armor
+      horse_armor: nexo:item/nexo_armor/forest_horse_armor
 ```


### PR DESCRIPTION
# Previously the following was the case:

forest_wolf_armor:
  itemname: "Forest Wolf Armor"
  material: WOLF_ARMOR
  Pack:
    texture: nexo:item/nexo_armor/forest_wolf_armor_icon
    CustomArmor:
      llama_armor: nexo:item/nexo_armor/forest_wolf_armor

forest_llama_armor:
  itemname: "Forest Llama Carpet"
  material: PAPER
  Pack:
    texture: nexo:item/nexo_armor/forest_llama_armor_icon
    CustomArmor:
      llama_armor: nexo:item/nexo_armor/forest_llama_armor

forest_horse_armor:
  itemname: "Forest Horse Armor"
  material: DIAMOND_HORSE_ARMOR
  Pack:
    texture: nexo:item/nexo_armor/forest_horse_armor_icon
    CustomArmor:
      llama_armor: nexo:item/nexo_armor/forest_horse_armor

# Now it's like this:

forest_wolf_armor:
  itemname: "Forest Wolf Armor"
  material: WOLF_ARMOR
  Pack:
    texture: nexo:item/nexo_armor/forest_wolf_armor_icon
    CustomArmor:
      wolf_armor: nexo:item/nexo_armor/forest_wolf_armor

forest_llama_armor:
  itemname: "Forest Llama Carpet"
  material: PAPER
  Pack:
    texture: nexo:item/nexo_armor/forest_llama_armor_icon
    CustomArmor:
      wolf_armor: nexo:item/nexo_armor/forest_llama_armor

forest_horse_armor:
  itemname: "Forest Horse Armor"
  material: DIAMOND_HORSE_ARMOR
  Pack:
    texture: nexo:item/nexo_armor/forest_horse_armor_icon
    CustomArmor:
      horse_armor: nexo:item/nexo_armor/forest_horse_armor