### PR TITLE
fix: Incorrect yes and no button options for Confirmation Type

### DIFF
--- a/configuration/dialogs/dialogtype.md
+++ b/configuration/dialogs/dialogtype.md
@@ -46,9 +46,9 @@ Contains two properties, **yes & no**, both which are **DialogActions**
 
 ```yaml
 type: CONFIRM
-yes:
+yesButton:
   ...
-no:
+noButton:
   ...
 ```
 


### PR DESCRIPTION
See title, it must be `yesButton` and `noButton` respectively, thanks to Naimad on Discord for helping me troubleshoot!

- Technofied